### PR TITLE
Fix initial loading of existing files 

### DIFF
--- a/grails-app/taglib/org/grails/plugins/bootstrap/file/upload/BootstrapFileUploadTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugins/bootstrap/file/upload/BootstrapFileUploadTagLib.groovy
@@ -211,7 +211,7 @@ class BootstrapFileUploadTagLib {
                 out << """
                     \$('#${id}').each(function () {
                         var that = this;
-                        \$.getJSON(this.action, ${formData ? '{' + formData.collect{k,v->k+':'+v}.join(',') + '}' : '{}'}, function (result) {
+                        \$.getJSON(this.action, ${formData ? '{' + formData.collect{k,v->k+':'+'\''+v+'\''}.join(',') + '}' : '{}'}, function (result) {
                             if (result && result.length) {
                                 \$(that).fileupload('option', 'done').call(that, null, {result: result});
                             }


### PR DESCRIPTION
When specifying formData, this will be put in two places. One is the initialization of the plugin, the second spot is the initial loading of existing files. At the second place the values of the object weren't quoted properly and the ajax call failed when formData consisted of strings.
