### PR TITLE
Removed Spurious Quotes from _download.gsp template

### DIFF
--- a/grails-app/views/bootstrapFileUpload/_download.gsp
+++ b/grails-app/views/bootstrapFileUpload/_download.gsp
@@ -53,6 +53,6 @@
       <span>${message(code:'fileupload.destroy')}</span>
     </button>
     <input type="checkbox" name="delete" value="1">
-  </td>"""
+  </td>
 </tr>
 {% } %}


### PR DESCRIPTION
Running the file upload plugin on an IE9 browser revealed spurious double-quotes above the list of downloadable files. 

Removed the three quotes from the end of the _download.gsp
