### PR TITLE
make binding of file upload separate step

### DIFF
--- a/grails-app/taglib/org/grails/plugins/bootstrap/file/upload/BootstrapFileUploadTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugins/bootstrap/file/upload/BootstrapFileUploadTagLib.groovy
@@ -92,7 +92,7 @@ class BootstrapFileUploadTagLib {
         String id = attrs.id ?: 'fileupload'
         String url = createLink(controller: attrs.controller, action: attrs.action)
 
-		String autoBind = attrs.autoBind ?: "n"
+		String autoBind = attrs.autoBind ?: "y"
 
         HttpMethod type = attrs.type ? HttpMethod.valueOf(attrs.type) : HttpMethod.POST
         String dataType = attrs.dataType ?: 'json'

--- a/grails-app/taglib/org/grails/plugins/bootstrap/file/upload/BootstrapFileUploadTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugins/bootstrap/file/upload/BootstrapFileUploadTagLib.groovy
@@ -92,6 +92,8 @@ class BootstrapFileUploadTagLib {
         String id = attrs.id ?: 'fileupload'
         String url = createLink(controller: attrs.controller, action: attrs.action)
 
+		String autoBind = attrs.autoBind ?: "n"
+
         HttpMethod type = attrs.type ? HttpMethod.valueOf(attrs.type) : HttpMethod.POST
         String dataType = attrs.dataType ?: 'json'
         String namespace = attrs.namespace ?: id
@@ -166,7 +168,7 @@ class BootstrapFileUploadTagLib {
 
         out << r.script(null) {
             out << """
-                \$(function(){
+			function bindFileUpload() { 
                     \$('#${id}').fileupload({
                         url: '${url}',
                         ${type ? "type: '${type}'," : ""}
@@ -219,9 +221,13 @@ class BootstrapFileUploadTagLib {
                     });"""
             }
             out << """
-                 });
+                 };
             """
         }
+
+		if(autoBind=='y') {
+			out << "\nbindFileUpload();\n"
+		}
 
         out << """
 <!-- The template to display files available for upload -->


### PR DESCRIPTION
taglib currently is one shot - but sometimes the div I want to attach to is not yet available.

this patch allows for the taglib to print out the fileupload params in to a function (bindFileUpload) that can be invoked later, or defaults to 'autoBind' of 'y' (new attribute parameter).
